### PR TITLE
Add estimated remaining size method

### DIFF
--- a/src/cloud_service.cpp
+++ b/src/cloud_service.cpp
@@ -426,6 +426,9 @@ int CloudService::send(const char *event,
 int CloudService::send(PublishFlags publish_flags, CloudServicePublishFlags cloud_flags, cloud_service_send_cb_t cb, unsigned int timeout_ms, const void *context)
 {
     int rval = 0;
+    // NOTE: if this JSON object close code changes then estimatedEndCommandSize() must be updated.
+    // The general pattern is:
+    //       ,\"req_id\":0000000000}
     uint32_t req_id = (cb && (cloud_flags & CloudServicePublishFlags::FULL_ACK)) ? get_next_req_id() : 0;
 
     if(req_id)

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -104,6 +104,7 @@ class CloudService
         // starts a new command/ack
         int beginCommand(const char *cmd);
         int beginResponse(const char *cmd, JSONValue &root);
+        size_t estimatedEndCommandSize() const;
 
         int send(PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
@@ -195,6 +196,12 @@ class CloudService
 
         RecursiveMutex mutex;
 };
+
+inline size_t CloudService::estimatedEndCommandSize() const {
+    // this is the worst case estimate for closing a publish message.  Any outgoing
+    // message should have this string fit.
+    return sizeof(",\"req_id\":}") - 1 /* null */ + 10 /* digits in uint32_t */;
+}
 
 template <typename T>
 int CloudService::regCommandCallback(const char *name,


### PR DESCRIPTION
Added a method to report the estimated remaining size needed for the JSON object.  It is very useful when needing to fill up available space in a limited size packet and make sure the main JSON object can be closed.