### PR TITLE
Perform preliminary check on JSON string format prior to parsing it.

### DIFF
--- a/src/cloud_service.cpp
+++ b/src/cloud_service.cpp
@@ -197,6 +197,28 @@ static int _get_common_fields(JSONValue &root, const char **cmd, const char **sr
 int CloudService::dispatchCommand(String data)
 {
     Log.info("cloud received: %s", data.c_str());
+
+    // Perform initial validation
+    const char *jsonStr = data.c_str();
+    char * ptr;
+    int    delimiter = ':';
+    ptr = strchr( jsonStr, delimiter );
+    while( nullptr != ptr )
+    {
+        // 
+        // A properly formatted JSON should be:
+        // {"cmd":"xxx"}
+        // Check if the preceding character to the [:] is the ["] termination in the <key, value> pair
+        //
+        if( *(ptr-1) != '"')
+        {
+            // Improperly formed command
+            return -EINVAL;
+        }
+
+        ptr = strchr( ptr+1, delimiter );
+    }
+    
     JSONValue root = JSONValue::parseCopy(data, data.length());
     int rval = -ENOENT;
 


### PR DESCRIPTION
From this [Notion story](https://app.shortcut.com/particle/story/108218/tracker-edge-crashes-to-sos-with-invalid-command), Tracker Edge crashes when a badly formed JSON string is sent from a Cloud "cmd" call. The device flashes the red LED SOS pattern and resets. This pull request performs a preliminary check on the JSON string before passing it to the JSON parser library in DeviceOS.  If the JSON string is invalid, an error return code is passed and the command does not get processed by the command handler.