### PR TITLE
Separate CloudService and LocationPublish

### DIFF
--- a/src/cloud_service.cpp
+++ b/src/cloud_service.cpp
@@ -18,21 +18,21 @@
 
 #include "cloud_service.h"
 
-#include "LocationPublish.h"
+#include "BackgroundPublish.h"
 
 #include <string.h>
 
 CloudService *CloudService::_instance = nullptr;
 
 CloudService::CloudService() :
-    _writer(json_buf, sizeof(json_buf)), _req_id(1)
+    _writer(json_buf, sizeof(json_buf)), _req_id(1), background_publish()
 {
 }
 
 void CloudService::init()
 {
     Particle.function("cmd", &CloudService::dispatchCommand, this);
-    BackgroundPublish::instance().init();
+    background_publish.start();
 }
 
 void CloudService::tick()
@@ -112,13 +112,6 @@ int CloudService::regCommandCallback(const char *cmd, cloud_service_cb_t cb, uin
     handlers.push_front(handler);
 
     return 0;
-}
-
-void CloudService::regCommandDeferredCallback(const cloud_service_handler_t &handler)
-{
-    std::lock_guard<RecursiveMutex> lg(mutex);
-
-    deferred_handlers.push_front(handler);
 }
 
 static int _get_common_fields(JSONValue &root, const char **cmd, const char **src_cmd, uint32_t *req_id, uint32_t *timestamp)
@@ -303,6 +296,34 @@ int CloudService::send_cb_wrapper(CloudServiceStatus status, JSONValue *rsp_root
     return rval;
 }
 
+void CloudService::publish_cb(
+    particle::Error error,
+    const char *event_name,
+    const char *event_data,
+    const void *event_context)
+{
+    std::lock_guard<RecursiveMutex> lg(mutex);
+
+    if(!event_context) {
+        return;
+    }
+
+    cloud_service_handler_t &handler = ((cloud_service_send_handler_t *) event_context)->base_handler;
+
+    if(error == Error::NONE) {
+        if(handler.cloud_flags & CloudServicePublishFlags::FULL_ACK) {
+            // expecting full end-to-end acknowledgement so set up handler waiting for the ACK
+            regCommandCallback(handler.cmd, handler.cb, handler.req_id, handler.timeout_ms, handler.context);
+        } else {
+            handler.status = CloudServiceStatus::SUCCESS;
+            deferred_handlers.push_front(handler);
+        }
+    } else {
+        handler.status = CloudServiceStatus::FAILURE;
+        deferred_handlers.push_front(handler);
+    }
+}
+
 int CloudService::send(const char *event,
     PublishFlags publish_flags,
     CloudServicePublishFlags cloud_flags,
@@ -311,7 +332,7 @@ int CloudService::send(const char *event,
     const void *context,
     const char *event_name,
     uint32_t req_id,
-    int level)
+    std::size_t priority)
 {
     int rval = 0;
     size_t event_len = strlen(event);
@@ -337,7 +358,7 @@ int CloudService::send(const char *event,
     // much simpler if there is no callback and can just publish into the void
     if(!cb)
     {
-        if(!LocationPublish::instance().publish(_writer_event_name, event, PRIVATE, level))
+        if (!background_publish.publish(_writer_event_name, event, PRIVATE, priority))
         {
             rval = -EBUSY;
         }
@@ -365,29 +386,25 @@ int CloudService::send(const char *event,
     
     // allocate space for handler info and copy of requesting event
     cloud_service_send_handler_t *send_handler  = new cloud_service_send_handler_t;
-    
-    if(!send_handler)
-    {
-        rval = -ENOMEM;
+    if (!send_handler) {
+        return -ENOMEM;
     }
-    else
-    {
-        send_handler->base_handler.cloud_flags = cloud_flags;
-        send_handler->base_handler.cb = send_cb_wrapper;
-        send_handler->base_handler.cmd[0] = '\0';
-        send_handler->base_handler.req_id = req_id;
-        send_handler->base_handler.timeout_ms = timeout_ms;
-        send_handler->base_handler.context = send_handler;
 
-        send_handler->cb = cb;
-        send_handler->context = context;
-        send_handler->req_data = event;
-        if(!LocationPublish::instance().publish(_writer_event_name, event, 
-                                    publish_flags | PRIVATE, level, send_handler))
-        {
-            delete send_handler;
-            rval = -EBUSY;
-        }
+    send_handler->base_handler.cloud_flags = cloud_flags;
+    send_handler->base_handler.cb = send_cb_wrapper;
+    send_handler->base_handler.cmd[0] = '\0';
+    send_handler->base_handler.req_id = req_id;
+    send_handler->base_handler.timeout_ms = timeout_ms;
+    send_handler->base_handler.context = send_handler;
+
+    send_handler->cb = cb;
+    send_handler->context = context;
+    send_handler->req_data = event;
+    if(!background_publish.publish(_writer_event_name, event,
+                                   publish_flags | PRIVATE, priority, &CloudService::publish_cb, this, send_handler))
+    {
+        delete send_handler;
+        rval = -EBUSY;
     }
 
     if(!rval)
@@ -403,7 +420,7 @@ int CloudService::send(PublishFlags publish_flags,
                     cloud_service_send_cb_t cb, 
                     unsigned int timeout_ms, 
                     const void *context, 
-                    int level)
+                    std::size_t priority)
 {
     int rval = 0;
     // NOTE: if this JSON object close code changes then estimatedEndCommandSize() must be updated.
@@ -428,7 +445,7 @@ int CloudService::send(PublishFlags publish_flags,
     // ensure null termination of the output json
     writer().buffer()[writer().dataSize()] = '\0';
 
-    rval = send(writer().buffer(), publish_flags, cloud_flags, cb, timeout_ms, context, _writer_event_name, req_id, level);
+    rval = send(writer().buffer(), publish_flags, cloud_flags, cb, timeout_ms, context, _writer_event_name, req_id, priority);
 
     unlock();
     return rval;

--- a/src/cloud_service.cpp
+++ b/src/cloud_service.cpp
@@ -310,7 +310,7 @@ void CloudService::publish_cb(
 
     cloud_service_handler_t &handler = ((cloud_service_send_handler_t *) event_context)->base_handler;
 
-    if(error == Error::NONE) {
+    if(Error::NONE == error) {
         if(handler.cloud_flags & CloudServicePublishFlags::FULL_ACK) {
             // expecting full end-to-end acknowledgement so set up handler waiting for the ACK
             regCommandCallback(handler.cmd, handler.cb, handler.req_id, handler.timeout_ms, handler.context);


### PR DESCRIPTION
`CloudService` should not depend on `LocationPublish`. This change is close to restoring `CloudService` to its prior state but using the updated `BackgroundPublish` library.