### PR TITLE
Refactor Cloud service callback handling

### DIFF
--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -195,7 +195,7 @@ class CloudService
         uint32_t last_tick_sec;
 
         std::list<cloud_service_handler_t> handlers;
-        std::list<cloud_service_handler_t> deferred_handlers;
+        std::list<std::function<int()>> deferred_handlers;
 
         RecursiveMutex mutex;
 };

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <functional>
 #include <list>
+#include <utility>
 
 enum CloudServiceStatus {
     SUCCESS = 0,
@@ -152,6 +153,8 @@ class CloudService
         // process and dispatch incoming commands to registered callbacks
         int dispatchCommand(String cmd);
 
+        int regCommand(const char *name, std::function<int(JSONValue *)> handler);
+
         int regCommandCallback(const char *name, cloud_service_cb_t cb, uint32_t req_id=0, uint32_t timeout_ms=0, const void *context=nullptr);
 
         template <typename T>
@@ -195,6 +198,7 @@ class CloudService
         uint32_t last_tick_sec;
 
         std::list<cloud_service_handler_t> handlers;
+        std::list<std::pair<String, std::function<int(JSONValue *)>>> command_handlers;
         std::list<std::function<int()>> deferred_handlers;
 
         RecursiveMutex mutex;

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -35,6 +35,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <list>
 #include <utility>
 
@@ -49,33 +50,13 @@ enum CloudServicePublishFlags {
     FULL_ACK = 0x01 // full end-to-end acknowledgement
 };
 
-typedef std::function<int(CloudServiceStatus status, JSONValue *, const void *context)> cloud_service_cb_t;
+using cloud_service_ack_cb_t = std::function<int(CloudServiceStatus, JSONValue *, String)>;
 
-typedef std::function<int(CloudServiceStatus status, JSONValue *, const char *, const void *context)> cloud_service_send_cb_t;
-
-class cloud_service_handler_t
-{
-public:
-    CloudServicePublishFlags cloud_flags;
-    cloud_service_cb_t cb;
-    // match on this cmd (or blank for don't care)
-    char cmd[CLOUD_MAX_CMD_LEN + 1];
-    // match on this req_id (or 0 don't care)
-    uint32_t req_id;
-    // fail on match after a timeout, or 0 for never timeout
-    uint32_t timeout_ms;
-    const void *context;
-    uint32_t t0;
-    CloudServiceStatus status;
-};
-
-class cloud_service_send_handler_t
-{
-public:
-    cloud_service_handler_t base_handler;
-    cloud_service_send_cb_t cb;
-    const void *context;
-    String req_data;
+struct cloud_service_ack_handler {
+    std::uint32_t req_id;
+    system_tick_t timeout; // absolute time of timeout, compared against millis()
+    cloud_service_ack_cb_t callback;
+    String data; // copy of original payload
 };
 
 class CloudService
@@ -105,43 +86,45 @@ class CloudService
         int beginResponse(const char *cmd, JSONValue &root);
         size_t estimatedEndCommandSize() const;
 
+        int send(const char *data,
+            PublishFlags publish_flags = PRIVATE,
+            CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
+            cloud_service_ack_cb_t cb=nullptr,
+            unsigned int timeout_ms=std::numeric_limits<system_tick_t>::max(),
+            const char *event_name=nullptr,
+            uint32_t req_id=0,
+            std::size_t priority=0u);
+
         int send(PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            cloud_service_send_cb_t cb=nullptr,
-            unsigned int timeout_ms=0,
-            const void *context=nullptr,
+            cloud_service_ack_cb_t cb=nullptr,
+            unsigned int timeout_ms=std::numeric_limits<system_tick_t>::max(),
             std::size_t priority=0u);
 
         template <typename T>
         int send(PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            int (T::*cb)(CloudServiceStatus status, JSONValue *, const char *, const void *context)=nullptr,
+            int (T::*cb)(CloudServiceStatus status, JSONValue *, String)=nullptr,
             T *instance=nullptr,
-            uint32_t timeout_ms=0,
-            const void *context=nullptr,
-            std::size_t priority=0u);
-
-        int send(const char *data,
-            PublishFlags publish_flags = PRIVATE,
-            CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            cloud_service_send_cb_t cb=nullptr,
-            unsigned int timeout_ms=0,
-            const void *context=nullptr,
-            const char *event_name=nullptr,
-            uint32_t req_id=0,
-            std::size_t priority=0u);
+            uint32_t timeout_ms=std::numeric_limits<system_tick_t>::max(),
+            std::size_t priority=0u)
+        {
+            return send(publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), timeout_ms, priority);
+        }
 
         template <typename T>
         int send(const char *data,
             PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            int (T::*cb)(CloudServiceStatus status, JSONValue *, const char *, const void *context)=nullptr,
+            int (T::*cb)(CloudServiceStatus status, JSONValue *, String)=nullptr,
             T *instance=nullptr,
-            uint32_t timeout_ms=0,
-            const void *context=nullptr,
+            uint32_t timeout_ms=std::numeric_limits<system_tick_t>::max(),
             const char *event_name=nullptr,
             uint32_t req_id=0,
-            std::size_t priority=0u);
+            std::size_t priority=0u)
+        {
+            return send(data, publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), timeout_ms, event_name, req_id, priority);
+        }
 
         int sendAck(JSONValue &root, int status);
 
@@ -155,15 +138,7 @@ class CloudService
 
         int regCommand(const char *name, std::function<int(JSONValue *)> handler);
 
-        int regCommandCallback(const char *name, cloud_service_cb_t cb, uint32_t req_id=0, uint32_t timeout_ms=0, const void *context=nullptr);
-
-        template <typename T>
-        int regCommandCallback(const char *name,
-            int (T::*cb)(CloudServiceStatus status, JSONValue *, const void *context),
-            T *instance,
-            uint32_t req_id=0,
-            uint32_t timeout_ms=0,
-            const void *context=nullptr);
+        int registerAckCallback(cloud_service_ack_handler);
 
     private:
         CloudService();
@@ -176,12 +151,8 @@ class CloudService
             particle::Error status,
             const char *event_name,
             const char *event_data,
-            const cloud_service_send_handler_t *send_handler);
-
-        // internal callback wrapper on the send path
-        static int send_cb_wrapper(CloudServiceStatus status,
-            JSONValue *rsp_root,
-            const void *send_handler);
+            const bool full_ack_required,
+            cloud_service_ack_handler send_handler);
 
         // process infrequent actions
         void tick_sec();
@@ -197,7 +168,7 @@ class CloudService
 
         uint32_t last_tick_sec;
 
-        std::list<cloud_service_handler_t> handlers;
+        std::list<cloud_service_ack_handler> handlers;
         std::list<std::pair<String, std::function<int(JSONValue *)>>> command_handlers;
         std::list<std::function<int()>> deferred_handlers;
 
@@ -208,45 +179,6 @@ inline size_t CloudService::estimatedEndCommandSize() const {
     // this is the worst case estimate for closing a publish message.  Any outgoing
     // message should have this string fit.
     return sizeof(",\"req_id\":}") - 1 /* null */ + 10 /* digits in uint32_t */;
-}
-
-template <typename T>
-int CloudService::regCommandCallback(const char *name,
-    int (T::*cb)(CloudServiceStatus status, JSONValue *, const void *context),
-    T *instance,
-    uint32_t req_id,
-    uint32_t timeout_ms,
-    const void *context)
-{
-    return regCommandCallback(name, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), req_id, timeout_ms, context);
-}
-
-template <typename T>
-int CloudService::send(PublishFlags publish_flags,
-    CloudServicePublishFlags cloud_flags,
-    int (T::*cb)(CloudServiceStatus status, JSONValue *, const char *, const void *context),
-    T *instance,
-    uint32_t timeout_ms,
-    const void *context,
-    std::size_t priority)
-{
-    return send(publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), timeout_ms, context, priority);
-}
-
-
-template <typename T>
-int CloudService::send(const char *event,
-    PublishFlags publish_flags,
-    CloudServicePublishFlags cloud_flags,
-    int (T::*cb)(CloudServiceStatus status, JSONValue *, const char *, const void *context),
-    T *instance,
-    uint32_t timeout_ms,
-    const void *context,
-    const char *event_name,
-    uint32_t req_id,
-    std::size_t priority)
-{
-    return send(event, publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), timeout_ms, context, event_name, req_id, priority);
 }
 
 void log_json(const char *json, size_t size);

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -37,9 +37,6 @@
 #include <functional>
 #include <list>
 
-using namespace std::placeholders;
-
-
 enum CloudServiceStatus {
     SUCCESS = 0,
     FAILURE, // publish to Particle cloud failed, etc
@@ -123,7 +120,7 @@ class CloudService
             const void *context=nullptr,
             std::size_t priority=0u);
 
-        int send(const char *event,
+        int send(const char *data,
             PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
             cloud_service_send_cb_t cb=nullptr,
@@ -134,7 +131,7 @@ class CloudService
             std::size_t priority=0u);
 
         template <typename T>
-        int send(const char *event,
+        int send(const char *data,
             PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
             int (T::*cb)(CloudServiceStatus status, JSONValue *, const char *, const void *context)=nullptr,
@@ -217,7 +214,7 @@ int CloudService::regCommandCallback(const char *name,
     uint32_t timeout_ms,
     const void *context)
 {
-    return regCommandCallback(name, std::bind(cb, instance, _1, _2, _3), req_id, timeout_ms, context);
+    return regCommandCallback(name, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), req_id, timeout_ms, context);
 }
 
 template <typename T>
@@ -229,7 +226,7 @@ int CloudService::send(PublishFlags publish_flags,
     const void *context,
     std::size_t priority)
 {
-    return send(publish_flags, cloud_flags, std::bind(cb, instance, _1, _2, _3, _4), timeout_ms, context, priority);
+    return send(publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), timeout_ms, context, priority);
 }
 
 
@@ -245,7 +242,7 @@ int CloudService::send(const char *event,
     uint32_t req_id,
     std::size_t priority)
 {
-    return send(event, publish_flags, cloud_flags, std::bind(cb, instance, _1, _2, _3, _4), timeout_ms, context, event_name, req_id, priority);
+    return send(event, publish_flags, cloud_flags, std::bind(cb, instance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), timeout_ms, context, event_name, req_id, priority);
 }
 
 void log_json(const char *json, size_t size);

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -176,12 +176,12 @@ class CloudService
             particle::Error status,
             const char *event_name,
             const char *event_data,
-            const void *event_context);
+            const cloud_service_send_handler_t *send_handler);
 
         // internal callback wrapper on the send path
         static int send_cb_wrapper(CloudServiceStatus status,
             JSONValue *rsp_root,
-            const void *context);
+            const void *send_handler);
 
         // process infrequent actions
         void tick_sec();

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -50,7 +50,7 @@ enum CloudServicePublishFlags {
     FULL_ACK = 0x01 // full end-to-end acknowledgement
 };
 
-using cloud_service_ack_cb_t = std::function<int(CloudServiceStatus, JSONValue *, String)>;
+using cloud_service_ack_cb_t = std::function<int(CloudServiceStatus, JSONValue *, String&&)>;
 
 struct cloud_service_ack_handler {
     std::uint32_t req_id;
@@ -104,7 +104,7 @@ class CloudService
         template <typename T>
         int send(PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            int (T::*cb)(CloudServiceStatus status, JSONValue *, String)=nullptr,
+            int (T::*cb)(CloudServiceStatus status, JSONValue *, String&&)=nullptr,
             T *instance=nullptr,
             uint32_t timeout_ms=std::numeric_limits<system_tick_t>::max(),
             std::size_t priority=0u)
@@ -116,7 +116,7 @@ class CloudService
         int send(const char *data,
             PublishFlags publish_flags = PRIVATE,
             CloudServicePublishFlags cloud_flags = CloudServicePublishFlags::NONE,
-            int (T::*cb)(CloudServiceStatus status, JSONValue *, String)=nullptr,
+            int (T::*cb)(CloudServiceStatus status, JSONValue *, String&&)=nullptr,
             T *instance=nullptr,
             uint32_t timeout_ms=std::numeric_limits<system_tick_t>::max(),
             const char *event_name=nullptr,
@@ -138,7 +138,7 @@ class CloudService
 
         int regCommand(const char *name, std::function<int(JSONValue *)> handler);
 
-        int registerAckCallback(cloud_service_ack_handler);
+        int registerAckCallback(cloud_service_ack_handler&&);
 
     private:
         CloudService();
@@ -152,7 +152,7 @@ class CloudService
             const char *event_name,
             const char *event_data,
             const bool full_ack_required,
-            cloud_service_ack_handler send_handler);
+            cloud_service_ack_handler&& send_handler);
 
         // process infrequent actions
         void tick_sec();

--- a/src/cloud_service.h
+++ b/src/cloud_service.h
@@ -84,7 +84,6 @@ class CloudService
         // starts a new command/ack
         int beginCommand(const char *cmd);
         int beginResponse(const char *cmd, JSONValue &root);
-        size_t estimatedEndCommandSize() const;
 
         int send(const char *data,
             PublishFlags publish_flags = PRIVATE,
@@ -174,11 +173,5 @@ class CloudService
 
         RecursiveMutex mutex;
 };
-
-inline size_t CloudService::estimatedEndCommandSize() const {
-    // this is the worst case estimate for closing a publish message.  Any outgoing
-    // message should have this string fit.
-    return sizeof(",\"req_id\":}") - 1 /* null */ + 10 /* digits in uint32_t */;
-}
 
 void log_json(const char *json, size_t size);

--- a/src/config_service.cpp
+++ b/src/config_service.cpp
@@ -165,9 +165,9 @@ ConfigService::ConfigService() :
 
 void ConfigService::init()
 {
-    CloudService::instance().regCommand("set_cfg", std::bind(&ConfigService::set_cfg_cb, this, std::placeholders::_1));
-    CloudService::instance().regCommand("get_cfg", std::bind(&ConfigService::get_cfg_cb, this, std::placeholders::_1));
-    CloudService::instance().regCommand("reset_to_factory", std::bind(&ConfigService::reset_to_factory_cb, this, std::placeholders::_1));
+    CloudService::instance().registerCommand("set_cfg", std::bind(&ConfigService::set_cfg_cb, this, std::placeholders::_1));
+    CloudService::instance().registerCommand("get_cfg", std::bind(&ConfigService::get_cfg_cb, this, std::placeholders::_1));
+    CloudService::instance().registerCommand("reset_to_factory", std::bind(&ConfigService::reset_to_factory_cb, this, std::placeholders::_1));
 
     struct stat st;
 
@@ -676,7 +676,7 @@ int ConfigService::reset_to_factory_cb(JSONValue *root)
 }
 
 // callback for ack to overall config sync with cloud (on boot)
-int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event)
+int ConfigService::sync_ack_cb(CloudServiceStatus status, String&& req_event)
 {
     if(status == CloudServiceStatus::SUCCESS && sync_pending)
     {
@@ -688,7 +688,7 @@ int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, Strin
 }
 
 // callback for ack to individual config sync with cloud
-int ConfigService::config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event)
+int ConfigService::config_sync_ack_cb(CloudServiceStatus status, String&& req_event)
 {
     if(status == CloudServiceStatus::SUCCESS)
     {

--- a/src/config_service.cpp
+++ b/src/config_service.cpp
@@ -676,7 +676,7 @@ int ConfigService::reset_to_factory_cb(JSONValue *root)
 }
 
 // callback for ack to overall config sync with cloud (on boot)
-int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event)
+int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event)
 {
     if(status == CloudServiceStatus::SUCCESS && sync_pending)
     {
@@ -688,7 +688,7 @@ int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, Strin
 }
 
 // callback for ack to individual config sync with cloud
-int ConfigService::config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event)
+int ConfigService::config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event)
 {
     if(status == CloudServiceStatus::SUCCESS)
     {

--- a/src/config_service.cpp
+++ b/src/config_service.cpp
@@ -239,8 +239,8 @@ void ConfigService::tick_sec()
                 cloud_service.beginCommand(CLOUD_CMD_SYNC);
                 cloud_service.writer().name("hash").value(_format_hash_str(hash_accum).c_str());
                 // TODO: Cloud is not sending app ack yet
-                // if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::FULL_ACK, &ConfigService::sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS, nullptr))
-                if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::NONE, &ConfigService::sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS, nullptr))
+                // if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::FULL_ACK, &ConfigService::sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS))
+                if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::NONE, &ConfigService::sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS))
                 {
                     sync_pending = true;
                 }
@@ -259,8 +259,8 @@ void ConfigService::tick_sec()
                         config_write_json(it.root, cloud_service.writer());
                         cloud_service.writer().endObject();
                         // TODO: Cloud is not sending app ack yet
-                        // if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::FULL_ACK, &ConfigService::config_sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS, nullptr))
-                        if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::NONE, &ConfigService::config_sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS, nullptr))
+                        // if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::FULL_ACK, &ConfigService::config_sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS))
+                        if(!cloud_service.send(WITH_ACK, CloudServicePublishFlags::NONE, &ConfigService::config_sync_ack_cb, this, CLOUD_DEFAULT_TIMEOUT_MS))
                         {
                             config_sync_pending_object = &it;
                             // possible config could be updated again before ack
@@ -676,7 +676,7 @@ int ConfigService::reset_to_factory_cb(JSONValue *root)
 }
 
 // callback for ack to overall config sync with cloud (on boot)
-int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context)
+int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event)
 {
     if(status == CloudServiceStatus::SUCCESS && sync_pending)
     {
@@ -688,7 +688,7 @@ int ConfigService::sync_ack_cb(CloudServiceStatus status, JSONValue *root, const
 }
 
 // callback for ack to individual config sync with cloud
-int ConfigService::config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context)
+int ConfigService::config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event)
 {
     if(status == CloudServiceStatus::SUCCESS)
     {

--- a/src/config_service.cpp
+++ b/src/config_service.cpp
@@ -165,9 +165,9 @@ ConfigService::ConfigService() :
 
 void ConfigService::init()
 {
-    CloudService::instance().regCommandCallback("set_cfg", &ConfigService::set_cfg_cb, this);
-    CloudService::instance().regCommandCallback("get_cfg", &ConfigService::get_cfg_cb, this);
-    CloudService::instance().regCommandCallback("reset_to_factory", &ConfigService::reset_to_factory_cb, this);
+    CloudService::instance().regCommand("set_cfg", std::bind(&ConfigService::set_cfg_cb, this, std::placeholders::_1));
+    CloudService::instance().regCommand("get_cfg", std::bind(&ConfigService::get_cfg_cb, this, std::placeholders::_1));
+    CloudService::instance().regCommand("reset_to_factory", std::bind(&ConfigService::reset_to_factory_cb, this, std::placeholders::_1));
 
     struct stat st;
 
@@ -554,7 +554,7 @@ int ConfigService::registerModule(ConfigNode &root)
 
 // callback for cloud "get_cfg" command
 // marks requested module(s) as dirty by invalidating the last synced crc
-int ConfigService::get_cfg_cb(CloudServiceStatus status, JSONValue *root, const void *context)
+int ConfigService::get_cfg_cb(JSONValue *root)
 {
     JSONValue *config = nullptr;
     JSONValue child;
@@ -602,7 +602,7 @@ int ConfigService::get_cfg_cb(CloudServiceStatus status, JSONValue *root, const 
 
 // callback for cloud "set_cfg" command
 // iterates and applies json config to the specified config descriptors
-int ConfigService::set_cfg_cb(CloudServiceStatus status, JSONValue *root, const void *context)
+int ConfigService::set_cfg_cb(JSONValue *root)
 {
     JSONValue *config = nullptr;
     JSONValue child;
@@ -666,7 +666,7 @@ int ConfigService::set_cfg_cb(CloudServiceStatus status, JSONValue *root, const 
     return rval;
 }
 
-int ConfigService::reset_to_factory_cb(CloudServiceStatus status, JSONValue *root, const void *context)
+int ConfigService::reset_to_factory_cb(JSONValue *root)
 {
     resetToFactory();
 

--- a/src/config_service.h
+++ b/src/config_service.h
@@ -91,8 +91,8 @@ class ConfigService
         int set_cfg_cb(JSONValue *root);
         int reset_to_factory_cb(JSONValue *root);
 
-        int sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event);
-        int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event);
+        int sync_ack_cb(CloudServiceStatus status, String&& req_event);
+        int config_sync_ack_cb(CloudServiceStatus status, String&& req_event);
 
         // process infrequent actions
         void tick_sec();

--- a/src/config_service.h
+++ b/src/config_service.h
@@ -91,8 +91,8 @@ class ConfigService
         int set_cfg_cb(JSONValue *root);
         int reset_to_factory_cb(JSONValue *root);
 
-        int sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context);
-        int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context);
+        int sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event);
+        int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event);
 
         // process infrequent actions
         void tick_sec();

--- a/src/config_service.h
+++ b/src/config_service.h
@@ -91,8 +91,8 @@ class ConfigService
         int set_cfg_cb(JSONValue *root);
         int reset_to_factory_cb(JSONValue *root);
 
-        int sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event);
-        int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String req_event);
+        int sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event);
+        int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, String&& req_event);
 
         // process infrequent actions
         void tick_sec();

--- a/src/config_service.h
+++ b/src/config_service.h
@@ -87,9 +87,9 @@ class ConfigService
 
         std::list<config_service_desc_t>::iterator get_module(const char *name);
 
-        int get_cfg_cb(CloudServiceStatus status, JSONValue *root, const void *context);
-        int set_cfg_cb(CloudServiceStatus status, JSONValue *root, const void *context);
-        int reset_to_factory_cb(CloudServiceStatus status, JSONValue *root, const void *context);
+        int get_cfg_cb(JSONValue *root);
+        int set_cfg_cb(JSONValue *root);
+        int reset_to_factory_cb(JSONValue *root);
 
         int sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context);
         int config_sync_ack_cb(CloudServiceStatus status, JSONValue *root, const char *req_event, const void *context);


### PR DESCRIPTION
Refactor the callback handling to avoid the 3-level callback architecture. The background publish callback is a lamdba to bind the publish details and original payload to `CloudService::publish_cb`, which will add a handler for the expected `ack` that calls the user callback, or prepares the user callback to be invoked in the next main loop invocation, if full acknowledgement is not required. The original payload data is copied only once, and moved using the move constructor to `String`.

Command callback handlers are separated from ack handlers, so parameters invalid for one or the other don't need to be assigned unused values.